### PR TITLE
disable frozen string literal cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -133,5 +133,8 @@ Style/RescueStandardError:
 Style/TernaryParentheses:
   EnforcedStyle: 'require_parentheses_when_complex'
 
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 Layout/LineLength:
   Max: 120


### PR DESCRIPTION
disable frozen string literal cop to bring inline with MyR https://github.com/CorporateRewards/myrewards/commit/0ddf88df1708504ad19c7a997b627377248cf14e

Missing frozen string literal comment. (convention:Style/FrozenStringLiteralComment)